### PR TITLE
Document fragmentize behavior of magic comments

### DIFF
--- a/pages/advanced-usage.md
+++ b/pages/advanced-usage.md
@@ -27,6 +27,8 @@ Magic comments are special comments which contents are interpreted by LTeX+ and 
 
 Magic comments are case-insensitive (except for the setting values), and the spaces in the magic comment line can be any amount of whitespace, even no amount at all.
 
+Magic commands trigger a reinitialization of LTeX+ due to potentially changed parameters. This causes the text section to be split at the position of the magic command, resulting in two requests being made to the language server. By using multiple trivial magic commands (e.g., `% LTeX:` for LaTeX), you can split a large file into smaller chunks, which are then sent for checking. Although this may slightly alter the output, it can be useful for avoiding API limits of the premium API (see [`ltex.languageToolHttpServerUri`](settings.html#ltexlanguagetoolhttpserveruri)).
+
 `SETTINGS` has to be replaced with a whitespace-separated list of `KEY=VALUE` pairs. Neither `KEY` nor `VALUE` are enclosed in quotation marks. The following settings are supported:
 
 - `enabled`: One of `true` or `false`. Makes it possible to disable LTeX+ for the rest of the document, or to enable it again.

--- a/pages/settings.md
+++ b/pages/settings.md
@@ -1445,6 +1445,8 @@ If set to a non-empty string, LTeX+ will not use the bundled, built-in version o
 
 Note that in this mode, the settings [`ltex.additionalRules.languageModel`](settings.html#ltexadditionalruleslanguagemodel), [`ltex.additionalRules.neuralNetworkModel`](settings.html#ltexadditionalrulesneuralnetworkmodel), and [`ltex.additionalRules.word2VecModel`](settings.html#ltexadditionalrulesword2vecmodel) will not take any effect.
 
+Please note that the premium API of [languagetool.org](languagetool.org) has a size limit per request. As a workaround, you can use magic comments to split a larger file into multiple fragments, which are then sent separately for checking (see Magic comments).
+
 *Type:* `string`
 
 *Example:* `"http://localhost:8081/"`

--- a/pages/settings.md
+++ b/pages/settings.md
@@ -1445,7 +1445,7 @@ If set to a non-empty string, LTeX+ will not use the bundled, built-in version o
 
 Note that in this mode, the settings [`ltex.additionalRules.languageModel`](settings.html#ltexadditionalruleslanguagemodel), [`ltex.additionalRules.neuralNetworkModel`](settings.html#ltexadditionalrulesneuralnetworkmodel), and [`ltex.additionalRules.word2VecModel`](settings.html#ltexadditionalrulesword2vecmodel) will not take any effect.
 
-Please note that the premium API of [languagetool.org](languagetool.org) has a size limit per request. As a workaround, you can use magic comments to split a larger file into multiple fragments, which are then sent separately for checking (see Magic comments).
+Please note that the premium API of [languagetool.org](https://languagetool.org) has a size limit per request (see [languagetool.org/http-api/](https://languagetool.org/http-api/)). As a workaround, you can use magic comments to split a larger file into multiple fragments, which are then sent separately for checking (see Magic comments).
 
 *Type:* `string`
 


### PR DESCRIPTION
- Also Insert hint for premium API, that magic comments can be used to split larger files in multiple fragments

I hope that this is the right way to contribute docs. I wasn't able to locally host the documenation since I got a problem running `docker compose up` and I have never used the Jekyll SSG 🤔