### PR TITLE
Listed `emacs-ltex-plus` in Official Extensions

### DIFF
--- a/pages/installation-usage.md
+++ b/pages/installation-usage.md
@@ -20,13 +20,14 @@ Choose the topmost scenario that applies to you.
 
 ## Via Editor Extensions
 
-LTeX+ publishes official extensions for Visual Studio Code (VS Code). For some other popular editors, third-party extensions exist that add support for LTeX+. If no extension exists yet for your editor, but your editor supports the Language Server Protocol (LSP), then you should be able to [use LTeX+ as a language client](#via-language-clients).
+LTeX+ publishes official extensions for Visual Studio Code (VS Code) and Emacs. For some other popular editors, third-party extensions exist that add support for LTeX+. If no extension exists yet for your editor, but your editor supports the Language Server Protocol (LSP), then you should be able to [use LTeX+ as a language client](#via-language-clients).
 
 ### Official Extensions
 
 | Editor | Extension | Link to instructions |
 | ------ | --------- | -------------------- |
-| [VS Code](https://code.visualstudio.com/) | vscode-ltex-plus  | [Instructions](vscode-ltex-plus/installation-usage-vscode-ltex-plus.html) |
+| [VS Code](https://code.visualstudio.com/) | vscode-ltex-plus | [Instructions](vscode-ltex-plus/installation-usage-vscode-ltex-plus.html) |
+| [Emacs](https://www.gnu.org/software/emacs/) + [lsp-mode](https://github.com/emacs-lsp/lsp-mode) | emacs-ltex-plus | [Instructions](https://github.com/ltex-plus/emacs-ltex-plus) |
 
 ### Third-Party Extensions
 
@@ -35,12 +36,11 @@ LTeX+ is not responsible for the quality of third-party extensions. The list and
 | Editor | Extension | Link to instructions |
 | ------ | --------- | -------------------- |
 | [Emacs](https://www.gnu.org/software/emacs/) + [eglot](https://github.com/joaotavora/eglot) | eglot-ltex-plus | [Instructions](https://github.com/emacs-languagetool/eglot-ltex-plus) |
-| [Emacs](https://www.gnu.org/software/emacs/) + [lsp-mode](https://github.com/emacs-lsp/lsp-mode) | emacs-ltex-plus&nbsp;∗ | [Instructions](https://github.com/alberti42/emacs-ltex-plus) |
-| [Emacs](https://www.gnu.org/software/emacs/) + [lsp-mode](https://github.com/emacs-lsp/lsp-mode) | lsp-ltex-plus | [Instructions](https://github.com/emacs-languagetool/lsp-ltex-plus) |
+| [Emacs](https://www.gnu.org/software/emacs/) + [lsp-mode](https://github.com/emacs-lsp/lsp-mode) | lsp-ltex-plus&nbsp;∗ | [Instructions](https://github.com/emacs-languagetool/lsp-ltex-plus) |
 | [Neovim](https://neovim.io/) + [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) | LTeX_extra.nvim | [Instructions](https://github.com/barreiroleo/ltex_extra.nvim) |
 | [Sublime Text](https://www.sublimetext.com/) | LSP-ltex-ls-plus | [Instructions](https://github.com/sublimelsp/LSP-ltex-ls) |
 
-∗ [`emacs-ltex-plus`](https://github.com/alberti42/emacs-ltex-plus) is a 2026 rewrite from scratch of the previous [`lsp-ltex-plus`](https://github.com/emacs-languagetool/lsp-ltex-plus), which was originally developed for the predecessor (and now archived) [LTeX](https://github.com/valentjn/ltex-ls) project.
+∗ [`lsp-ltex-plus`](https://github.com/emacs-languagetool/lsp-ltex-plus) was originally developed for the predecessor (and now archived) [LTeX](https://github.com/valentjn/ltex-ls) project. For a recent (2026) rewrite from scratch, see [`emacs-ltex-plus`](https://github.com/ltex-plus/emacs-ltex-plus) in the [Official Extensions](#official-extensions) section above.
 
 ## Via Language Clients
 


### PR DESCRIPTION
## Summary

`emacs-ltex-plus` is now maintained under the [ltex-plus](https://github.com/ltex-plus/) GitHub organization (moved from `alberti42/emacs-ltex-plus` per the invitation in ltex-ls-plus#148). This PR updates `pages/installation-usage.md` to reflect that change:

- Moved `emacs-ltex-plus` from the **Third-Party Extensions** table into the **Official Extensions** table, next to `vscode-ltex-plus`.
- Updated the repository link to the new canonical URL: <https://github.com/ltex-plus/emacs-ltex-plus>.
- Reworded the introductory sentence of "Via Editor Extensions" from "LTeX+ publishes official extensions for Visual Studio Code (VS Code)" to "...for Visual Studio Code (VS Code) and Emacs."
- Moved the footnote (`∗`) onto the `lsp-ltex-plus` row in the **Third-Party Extensions** table. The new footnote credits `lsp-ltex-plus` as the predecessor (originally developed for the archived [LTeX](https://github.com/valentjn/ltex-ls) project) and points readers to the recent (2026) rewrite, `emacs-ltex-plus`, in the Official Extensions section.

The other Emacs entries (`eglot-ltex-plus`, `lsp-ltex-plus`) remain in the Third-Party Extensions table. `lsp-ltex-plus` is kept in the list as a courtesy to credit its original author and to give users coming from older setups a clear path to the modern, official replacement.

The original `lsp-ltex-plus` never worked on my setup. One possibility is that the older Emacs plugin was affected by several bugs in Emacs' `lsp-mode` framework. I recently filed 5 PRs (see a short [overview](https://github.com/ltex-plus/emacs-ltex-plus#recommended-lsp-mode-revision) of the PRs, now merged upstream in `lsp-mode`) fixing hard-failure bugs that could explain why the original plugin never worked on modern `lsp-mode` versions. It is therefore possible that, now that these fixes have landed upstream, the old Emacs package works again. As of now, I do not know whether the old plugin runs correctly with the upstream fixes in `lsp-mode`, or whether other bugs are still blocking it. If I obtain more information on this in the future, I will add a note next to the asterisk on the installation-usage page so that users are properly informed.

## Note on documentation symmetry

For full symmetry with `vscode-ltex-plus`, the website could host dedicated installation/usage pages for `emacs-ltex-plus` (mirroring `pages/vscode-ltex-plus/`). I am deliberately deferring that work for now:

- The [`emacs-ltex-plus` README](https://github.com/ltex-plus/emacs-ltex-plus) already documents installation, configuration, and usage in detail.
- Duplicating that content onto the website would take a significant effort and create two sources of truth that must be kept in sync.

If it later becomes important to have first-class documentation pages on the main website for the Emacs extension, we can revisit this. For the moment, linking to the project README from the Official Extensions table seems like the simplest solution.

## Test plan

- [x] Build the site locally and confirm that `installation-usage.html` renders with `emacs-ltex-plus` in the Official Extensions table.
- [x] Verify the footnote (`∗`) appears directly under the Third-Party Extensions table, attached to the `lsp-ltex-plus` row, and that its in-page link to the Official Extensions section resolves.
- [x] Verify the link target <https://github.com/ltex-plus/emacs-ltex-plus> resolves correctly.
- [x] Verify the Third-Party Extensions table no longer lists `emacs-ltex-plus` and still lists `eglot-ltex-plus` and `lsp-ltex-plus`.
